### PR TITLE
cdn.ampproject.org

### DIFF
--- a/blocklists/src/Adware and Malware/UserSuggested.txt
+++ b/blocklists/src/Adware and Malware/UserSuggested.txt
@@ -56,7 +56,6 @@ casale-match.dotomi.com
 cdn-ssl.vidible.tv
 cdn.adnxs.com
 cdn.adrta.com
-cdn.ampproject.org
 cdn.districtm.io
 cdn.krxd.net
 cdn.seaofads.com


### PR DESCRIPTION
This domain breaks youtube embedded videos in the Google News app

Also, please allow the opening of Issues on the Git so we can report false positives without needing to make pull requests.